### PR TITLE
add tls:// transport layer for listeners

### DIFF
--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ func main() {
 			log.Fatal(err)
 		}
 
-		go local.ListenAndServe()
+		go local.ListenAndServe(nil)
 	}
 
 	sigCh := make(chan os.Signal, 1)

--- a/proxy/redir/redir_linux.go
+++ b/proxy/redir/redir_linux.go
@@ -64,7 +64,7 @@ func NewRedir6Server(s string, dialer proxy.Dialer) (proxy.Server, error) {
 }
 
 // ListenAndServe .
-func (s *RedirProxy) ListenAndServe() {
+func (s *RedirProxy) ListenAndServe(_ net.Conn) {
 	l, err := net.Listen("tcp", s.addr)
 	if err != nil {
 		log.F("[redir] failed to listen on %s: %v", s.addr, err)

--- a/proxy/server.go
+++ b/proxy/server.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"errors"
+	"net"
 	"net/url"
 	"strings"
 
@@ -11,7 +12,7 @@ import (
 // Server interface
 type Server interface {
 	// ListenAndServe as proxy server, use only in server mode.
-	ListenAndServe()
+	ListenAndServe(net.Conn)
 }
 
 // ServerCreator is a function to create proxy servers.

--- a/proxy/tcptun/tcptun.go
+++ b/proxy/tcptun/tcptun.go
@@ -48,7 +48,7 @@ func NewTCPTunServer(s string, dialer proxy.Dialer) (proxy.Server, error) {
 }
 
 // ListenAndServe .
-func (s *TCPTun) ListenAndServe() {
+func (s *TCPTun) ListenAndServe(_ net.Conn) {
 	l, err := net.Listen("tcp", s.addr)
 	if err != nil {
 		log.F("failed to listen on %s: %v", s.addr, err)

--- a/proxy/tls/tls.go
+++ b/proxy/tls/tls.go
@@ -130,10 +130,9 @@ func (s *TLS) ListenAndServe(c net.Conn) {
 
 		tlsConfig = &stdtls.Config{
 			Certificates:     []stdtls.Certificate{cert},
-			MinVersion:       stdtls.VersionTLS12,
-			MaxVersion:       stdtls.VersionTLS13,
+			MinVersion:       stdtls.VersionTLS10,
+			MaxVersion:       stdtls.VersionTLS12,
 			SessionTicketKey: ticketKey,
-			Accept0RTTData:   true,
 		}
 	} else {
 		tlsConfig = nil
@@ -184,8 +183,8 @@ func (s *TLS) Dial(network, addr string) (net.Conn, error) {
 		ServerName:         s.serverName,
 		InsecureSkipVerify: s.skipVerify,
 		ClientSessionCache: stdtls.NewLRUClientSessionCache(64),
-		MinVersion:         stdtls.VersionTLS12,
-		MaxVersion:         stdtls.VersionTLS13,
+		MinVersion:         stdtls.VersionTLS10,
+		MaxVersion:         stdtls.VersionTLS12,
 	}
 
 	c := stdtls.Client(cc, conf)

--- a/proxy/tls/tls.go
+++ b/proxy/tls/tls.go
@@ -3,6 +3,7 @@ package tls
 import (
 	stdtls "crypto/tls"
 	"errors"
+	"fmt"
 	"net"
 	"net/url"
 	"strings"
@@ -18,10 +19,17 @@ type TLS struct {
 
 	serverName string
 	skipVerify bool
+
+	certFile string
+	keyFile  string
+
+	server      proxy.Server
+	serverProto string
 }
 
 func init() {
 	proxy.RegisterDialer("tls", NewTLSDialer)
+	proxy.RegisterServer("tls", NewTLSTransport)
 }
 
 // NewTLS returns a tls proxy.
@@ -48,6 +56,8 @@ func NewTLS(s string, dialer proxy.Dialer) (*TLS, error) {
 		addr:       addr,
 		serverName: serverName,
 		skipVerify: false,
+		certFile:   "",
+		keyFile:    "",
 	}
 
 	if skipVerify == "true" {
@@ -55,6 +65,100 @@ func NewTLS(s string, dialer proxy.Dialer) (*TLS, error) {
 	}
 
 	return p, nil
+}
+
+// NewTLSServerTransport returns a tls transport layer before the real server
+func NewTLSTransport(s string, dialer proxy.Dialer) (proxy.Server, error) {
+	transport := strings.Split(s, ",")
+
+	// prepare transport listener
+	if len(transport) != 2 {
+		err := fmt.Errorf("malformd listener: %s", s)
+		log.F(err.Error())
+		return nil, err
+	}
+
+	u, err := url.Parse(transport[0])
+	if err != nil {
+		log.F("parse url err: %s", err)
+		return nil, err
+	}
+
+	// TODO: cert=&key=
+	query := u.Query()
+
+	certFile := query.Get("cert")
+	keyFile := query.Get("key")
+
+	addr := u.Host
+	colonPos := strings.LastIndex(addr, ":")
+	if colonPos == -1 {
+		colonPos = len(addr)
+	}
+	serverName := addr[:colonPos]
+
+	p := &TLS{
+		dialer:      dialer,
+		addr:        addr,
+		serverName:  serverName,
+		skipVerify:  false,
+		certFile:    certFile,
+		keyFile:     keyFile,
+		serverProto: transport[1],
+	}
+
+	// prepare layer 7 server
+	p.server, err = proxy.ServerFromURL(transport[1], dialer)
+
+	return p, nil
+}
+
+func (s *TLS) ListenAndServe(c net.Conn) {
+	// c for TCP_FAST_OPEN
+
+	var tlsConfig *stdtls.Config
+
+	var ticketKey [32]byte
+	copy(ticketKey[:], "f8710951c1f6d0d95a95eed5e99b51f1")
+
+	if s.certFile != "" && s.keyFile != "" {
+		cert, err := stdtls.LoadX509KeyPair(s.certFile, s.keyFile)
+		if err != nil {
+			log.F("unabled load cert: %s, key %s", s.certFile, s.keyFile)
+			return
+		}
+
+		tlsConfig = &stdtls.Config{
+			Certificates:     []stdtls.Certificate{cert},
+			MinVersion:       stdtls.VersionTLS12,
+			MaxVersion:       stdtls.VersionTLS13,
+			SessionTicketKey: ticketKey,
+			Accept0RTTData:   true,
+		}
+	} else {
+		tlsConfig = nil
+	}
+
+	l, err := stdtls.Listen("tcp", s.addr, tlsConfig)
+	if err != nil {
+		log.F("failed to listen on tls %s: %v", s.addr, err)
+		return
+	}
+
+	defer l.Close()
+
+	log.F("listening TCP on %s with TLS", s.addr)
+
+	for {
+		c, err := l.Accept()
+		if err != nil {
+			log.F("[https] failed to accept: %v", err)
+			continue
+		}
+
+		// it's callee's response to decide process request in sync/async mode.
+		s.server.ListenAndServe(c)
+	}
 }
 
 // NewTLSDialer returns a tls proxy dialer.
@@ -79,6 +183,9 @@ func (s *TLS) Dial(network, addr string) (net.Conn, error) {
 	conf := &stdtls.Config{
 		ServerName:         s.serverName,
 		InsecureSkipVerify: s.skipVerify,
+		ClientSessionCache: stdtls.NewLRUClientSessionCache(64),
+		MinVersion:         stdtls.VersionTLS12,
+		MaxVersion:         stdtls.VersionTLS13,
 	}
 
 	c := stdtls.Client(cc, conf)

--- a/proxy/tproxy/tproxy_linux.go
+++ b/proxy/tproxy/tproxy_linux.go
@@ -51,7 +51,7 @@ func NewTProxyServer(s string, dialer proxy.Dialer) (proxy.Server, error) {
 }
 
 // ListenAndServe .
-func (s *TProxy) ListenAndServe() {
+func (s *TProxy) ListenAndServe(_ net.Conn) {
 	// go s.ListenAndServeTCP()
 	s.ListenAndServeUDP()
 }

--- a/proxy/udptun/udptun.go
+++ b/proxy/udptun/udptun.go
@@ -50,7 +50,7 @@ func NewUDPTunServer(s string, dialer proxy.Dialer) (proxy.Server, error) {
 }
 
 // ListenAndServe .
-func (s *UDPTun) ListenAndServe() {
+func (s *UDPTun) ListenAndServe(_ net.Conn) {
 	c, err := net.ListenPacket("udp", s.addr)
 	if err != nil {
 		log.F("[udptun] failed to listen on %s: %v", s.addr, err)

--- a/proxy/uottun/uottun.go
+++ b/proxy/uottun/uottun.go
@@ -50,7 +50,7 @@ func NewUoTTunServer(s string, dialer proxy.Dialer) (proxy.Server, error) {
 }
 
 // ListenAndServe .
-func (s *UoTTun) ListenAndServe() {
+func (s *UoTTun) ListenAndServe(_ net.Conn) {
 	c, err := net.ListenPacket("udp", s.addr)
 	if err != nil {
 		log.F("[uottun] failed to listen on %s: %v", s.addr, err)


### PR DESCRIPTION
给所有的 listener 增加了 tls transport 支持

例如 socks5-tls 的 listener
`listen=tls://:443?cert=cert.pem&key=key.pem,socks5://`

另外给 http server 增加了一个  `pretend` 参数，利用 mixed:// 类型 listener 可以实现伪装为 web server 的 socks5-tls proxy

