### PR TITLE
adds HTTP PATCH support to the mixed proxy

### DIFF
--- a/proxy/mixed/mixed.go
+++ b/proxy/mixed/mixed.go
@@ -22,6 +22,7 @@ var httpMethods = [...][]byte{
 	[]byte("HEAD"),
 	[]byte("OPTIONS"),
 	[]byte("TRACE"),
+	[]byte("PATCH"),
 }
 
 // MixedProxy struct


### PR DESCRIPTION
Love Glider! It's saved our team tons of time. The only thing missing is support for proxying [`HTTP PATCH`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/PATCH) requests. I've got a little tweak here to add it.