### PR TITLE
strategy: add features latencythreshold

### DIFF
--- a/conf.go
+++ b/conf.go
@@ -41,6 +41,7 @@ func confInit() {
 	flag.StringVar(&conf.StrategyConfig.CheckWebSite, "checkwebsite", "www.apple.com", "proxy check HTTP(NOT HTTPS) website address, format: HOST[:PORT], default port: 80")
 	// TODO: change to checkinterval
 	flag.IntVar(&conf.StrategyConfig.CheckInterval, "checkduration", 30, "proxy check interval(seconds)")
+	flag.IntVar(&conf.StrategyConfig.LatencyThreshold, "latencythreshold", 10000, "proxy check latency time(millisecond)")
 	flag.IntVar(&conf.StrategyConfig.MaxFailures, "maxfailures", 3, "max failures to change forwarder status to disabled")
 	flag.StringVar(&conf.StrategyConfig.IntFace, "interface", "", "source ip or source interface")
 


### PR DESCRIPTION
服务器出现一些问题的时候，测试的延迟很大，基本处于不可用的状态
按照目前的流程，无法正确切换到其他服务器
所以增加一个延迟阀值 latencythreshold 来辅助判断服务器可用性 
默认配置为10s