### PR TITLE
redir, dns: IncFailures on non-timeout errors

### DIFF
--- a/dns/client.go
+++ b/dns/client.go
@@ -169,6 +169,9 @@ func (c *Client) exchange(qname string, reqBytes []byte, preferTCP bool) (
 		log.F("[dns] failed to exchange with server %v: %v", server, err)
 	}
 
+	if err != nil {
+		c.proxy.Record(dialer, false)
+	}
 	return server, network, dialer.Addr(), respBytes, err
 }
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -5,11 +5,14 @@ import "net"
 // Proxy is a dialer manager
 type Proxy interface {
 	// Dial connects to the given address via the proxy.
-	Dial(network, addr string) (c net.Conn, proxy string, err error)
+	Dial(network, addr string) (c net.Conn, dialer Dialer, err error)
 
 	// DialUDP connects to the given address via the proxy.
 	DialUDP(network, addr string) (pc net.PacketConn, writeTo net.Addr, err error)
 
 	// Get the dialer by dstAddr
 	NextDialer(dstAddr string) Dialer
+
+	// Record records result while using the dialer from proxy.
+	Record(dialer Dialer, success bool)
 }

--- a/proxy/redir/redir_linux.go
+++ b/proxy/redir/redir_linux.go
@@ -104,14 +104,14 @@ func (s *RedirProxy) Serve(c net.Conn) {
 		return
 	}
 
-	rc, p, err := s.proxy.Dial("tcp", tgt.String())
+	rc, dialer, err := s.proxy.Dial("tcp", tgt.String())
 	if err != nil {
-		log.F("[redir] %s <-> %s via %s, error in dial: %v", c.RemoteAddr(), tgt, p, err)
+		log.F("[redir] %s <-> %s via %s, error in dial: %v", c.RemoteAddr(), tgt, dialer.Addr(), err)
 		return
 	}
 	defer rc.Close()
 
-	log.F("[redir] %s <-> %s via %s", c.RemoteAddr(), tgt, p)
+	log.F("[redir] %s <-> %s via %s", c.RemoteAddr(), tgt, dialer.Addr())
 
 	_, _, err = conn.Relay(c, rc)
 	if err != nil {
@@ -119,6 +119,7 @@ func (s *RedirProxy) Serve(c net.Conn) {
 			return // ignore i/o timeout
 		}
 		log.F("[redir] relay error: %v", err)
+		s.proxy.Record(dialer, false)
 	}
 }
 

--- a/rule/rule.go
+++ b/rule/rule.go
@@ -10,6 +10,8 @@ import (
 	"github.com/nadoo/glider/strategy"
 )
 
+var _ proxy.Proxy = &Proxy{}
+
 // Proxy struct
 type Proxy struct {
 	proxy   *strategy.Proxy
@@ -47,7 +49,7 @@ func NewProxy(rules []*Config, proxy *strategy.Proxy) *Proxy {
 }
 
 // Dial dials to targer addr and return a conn
-func (p *Proxy) Dial(network, addr string) (net.Conn, string, error) {
+func (p *Proxy) Dial(network, addr string) (net.Conn, proxy.Dialer, error) {
 	return p.nextProxy(addr).Dial(network, addr)
 }
 
@@ -107,6 +109,11 @@ func (p *Proxy) nextProxy(dstAddr string) *strategy.Proxy {
 // NextDialer return next dialer according to rule
 func (p *Proxy) NextDialer(dstAddr string) proxy.Dialer {
 	return p.nextProxy(dstAddr).NextDialer(dstAddr)
+}
+
+// Record records result while using the dialer from proxy.
+func (p *Proxy) Record(dialer proxy.Dialer, success bool) {
+	p.proxy.Record(dialer, success)
 }
 
 // AddDomainIP used to update ipMap rules according to domainMap rule


### PR DESCRIPTION
Fix #83 

Main changes:
+ `proxy.Proxy` interface is modified to return the `Dialer` which the proxy selected,  and a`Record()` method is introduced to feedback dialer usage by callers.
+ `strategy.Forwarder` will immediately trigger `Disable()` in `IncFailures()`, e.g. when `Record()` with `success == false`.

Currently, `redir` and `dns` support disabling forwarder  when multiple errors happened, and this procedure can be easily introduced in other listeners based on the changes above.
