### PR TITLE
fix(vmess): choose security automaticly rather than using obsolete format

### DIFF
--- a/proxy/vmess/client.go
+++ b/proxy/vmess/client.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"math/rand"
 	"net"
+	"runtime"
 	"strings"
 	"time"
 
@@ -95,9 +96,10 @@ func NewClient(uuidStr, security string, alterID int) (*Client, error) {
 	case "none":
 		c.security = SecurityNone
 	case "":
-		// NOTE: use basic format when no method specified
-		c.opt = OptBasicFormat
-		c.security = SecurityNone
+		if runtime.GOARCH == "amd64" || runtime.GOARCH == "s390x" || runtime.GOARCH == "arm64" {
+			c.security = SecurityAES128GCM
+		}
+		c.security = SecurityChacha20Poly1305
 	default:
 		return nil, errors.New("unknown security type: " + security)
 	}


### PR DESCRIPTION
When no security is specific, automaticly choose rather than using obesolete format.

This action can fix failed connection to [soga-v2ray](https://github.com/sprov065/soga/) servers which is widely used for commercial usage.