### PR TITLE
feat:Support DOH and DOT

### DIFF
--- a/dns/client.go
+++ b/dns/client.go
@@ -52,8 +52,7 @@ func NewClient(proxy proxy.Proxy, config *Config) (*Client, error) {
 		config:      config,
 		upStream:    NewUPStream(config.Servers),
 		upStreamMap: make(map[string]*UPStream),
-		httpClient: &http.Client{
-		},
+		httpClient:  &http.Client{},
 	}
 
 	// custom records
@@ -193,7 +192,6 @@ func (c *Client) exchange(qname string, reqBytes []byte, preferTCP bool) (
 		case "doh":
 			net.DefaultResolver = &net.Resolver{}
 		default:
-			scheme=network
 			break
 		}
 		if e != nil {
@@ -212,7 +210,6 @@ func (c *Client) exchange(qname string, reqBytes []byte, preferTCP bool) (
 		if c.config.Timeout > 0 && scheme != "doh" {
 			rc.SetDeadline(time.Now().Add(time.Duration(c.config.Timeout) * time.Second))
 		}
-
 		switch scheme {
 		case "tcp", "dot":
 			respBytes, err = c.exchangeTCP(rc, reqBytes)

--- a/dns/client.go
+++ b/dns/client.go
@@ -202,7 +202,7 @@ func (c *Client) exchange(qname string, reqBytes []byte, preferTCP bool) (
 			server = newServer
 			continue
 		}
-		//TODO: if we use DOH (network=="doh") we don't need close connection
+		//TODO: if we use DOH (op=="doh") we don't need close connection
 		if op!="doh"{
 			defer rc.Close()
 		}

--- a/dns/client.go
+++ b/dns/client.go
@@ -203,12 +203,12 @@ func (c *Client) exchange(qname string, reqBytes []byte, preferTCP bool) (
 			continue
 		}
 		//TODO: if we use DOH (network=="doh") we don't need close connection
-		if network!="doh"{
+		if op!="doh"{
 			defer rc.Close()
 		}
 
 		// TODO: support timeout setting for different upstream server
-		if c.config.Timeout > 0 && network!="doh" {
+		if c.config.Timeout > 0 && op!="doh" {
 			rc.SetDeadline(time.Now().Add(time.Duration(c.config.Timeout) * time.Second))
 		}
 


### PR DESCRIPTION
I noticed that glider doesn't support DNT and DOH, so I added it. It also solves a problem in [issue.#190](https://github.com/nadoo/glider/issues/190) Now you can specify whether to select UDP or TCP or DOH and dot. I have done some examples to show

> test dot  we use dot:// xxx represent dot 

 `go run . -verbose -listen :1080 -dns :53 -dnsserver=dot://1.0.0.1:853 -dnsrecord=www.example.com/1.2.3.4`
`  [dns] 127.0.0.1:57384 <-> 1.0.0.1:853(dot) via DIRECT, type: 1, www.google.com: 216.58.217.196`

> test doh we use doh://xxxxxx represent doh

` go run . -verbose -listen :1080 -dns :53 -dnsserver=doh://1.0.0.1:443 -dnsrecord=www.example.com/1.2.3.4 ` 
` [dns] 127.0.0.1:63825 <-> 1.0.0.1:443(doh) via DIRECT, type: 1, www.google.com: 142.250.68.4`
> test set tcp  we use tcp://xxxxxx represent tcp
> test set udp  we use udp://xxxxxx represent udp
> if we not set special opion It's just the same as before