### PR TITLE
feat: support leastconn" strategy

### DIFF
--- a/rule/forward.go
+++ b/rule/forward.go
@@ -25,6 +25,7 @@ type Forwarder struct {
 	failures    uint32
 	latency     int64
 	intface     string // local interface or ip address
+	cntConn     int
 	handlers    []StatusHandler
 }
 
@@ -112,6 +113,9 @@ func (f *Forwarder) Dial(network, addr string) (c net.Conn, err error) {
 	c, err = f.Dialer.Dial(network, addr)
 	if err != nil {
 		f.IncFailures()
+	}
+	if IsLeastConn == true {
+		c = NewConn(c, f)
 	}
 	return c, err
 }

--- a/rule/proxy.go
+++ b/rule/proxy.go
@@ -17,7 +17,7 @@ type Proxy struct {
 	ipMap     sync.Map
 	cidrMap   sync.Map
 }
-
+var IsLeastConn bool //is use leastConn strategy
 // NewProxy returns a new rule proxy.
 func NewProxy(mainForwarders []string, mainStrategy *Strategy, rules []*Config) *Proxy {
 	rd := &Proxy{main: NewFwdrGroup("main", mainForwarders, mainStrategy)}

--- a/rule/umconn.go
+++ b/rule/umconn.go
@@ -1,0 +1,90 @@
+package rule
+
+import (
+	"net"
+	"time"
+)
+
+type Conn struct {
+	conn      net.Conn
+	forwarder *Forwarder
+}
+func NewConn( c net.Conn,forwarder *Forwarder) *Conn {
+	forwarder.cntConn++
+	return &Conn{
+		conn: c,
+		forwarder: forwarder,
+	}
+
+}
+// Read reads data from the connection.
+// Read can be made to time out and return an error after a fixed
+// time limit; see SetDeadline and SetReadDeadline.
+func (c *Conn) Read(b []byte) (n int, err error) {
+	return c.conn.Read(b)
+}
+
+// Write writes data to the connection.
+// Write can be made to time out and return an error after a fixed
+// time limit; see SetDeadline and SetWriteDeadline.
+func (c *Conn) Write(b []byte) (n int, err error) {
+	return c.conn.Write(b)
+}
+
+// Close closes the connection.
+// Any blocked Read or Write operations will be unblocked and return errors.
+func (c *Conn) Close() error {
+	c.forwarder.cntConn--
+	return c.conn.Close()
+}
+
+// LocalAddr returns the local network address.
+func (c *Conn) LocalAddr() net.Addr {
+	return c.conn.LocalAddr()
+}
+
+// RemoteAddr returns the remote network address.
+func (c *Conn) RemoteAddr() net.Addr {
+	return c.conn.RemoteAddr()
+}
+
+// SetDeadline sets the read and write deadlines associated
+// with the connection. It is equivalent to calling both
+// SetReadDeadline and SetWriteDeadline.
+//
+// A deadline is an absolute time after which I/O operations
+// fail instead of blocking. The deadline applies to all future
+// and pending I/O, not just the immediately following call to
+// Read or Write. After a deadline has been exceeded, the
+// connection can be refreshed by setting a deadline in the future.
+//
+// If the deadline is exceeded a call to Read or Write or to other
+// I/O methods will return an error that wraps os.ErrDeadlineExceeded.
+// This can be tested using errors.Is(err, os.ErrDeadlineExceeded).
+// The error's Timeout method will return true, but note that there
+// are other possible errors for which the Timeout method will
+// return true even if the deadline has not been exceeded.
+//
+// An idle timeout can be implemented by repeatedly extending
+// the deadline after successful Read or Write calls.
+//
+// A zero value for t means I/O operations will not time out.
+func (c *Conn) SetDeadline(t time.Time) error {
+	return c.conn.SetDeadline(t)
+}
+
+// SetReadDeadline sets the deadline for future Read calls
+// and any currently-blocked Read call.
+// A zero value for t means Read will not time out.
+func (c *Conn) SetReadDeadline(t time.Time) error {
+	return c.conn.SetReadDeadline(t)
+}
+
+// SetWriteDeadline sets the deadline for future Write calls
+// and any currently-blocked Write call.
+// Even if write times out, it may return n > 0, indicating that
+// some of the data was successfully written.
+// A zero value for t means Write will not time out.
+func (c *Conn) SetWriteDeadline(t time.Time) error {
+	return c.conn.SetWriteDeadline(t)
+}


### PR DESCRIPTION
solved issue.#205 
Although I added a file to rewrite net.conn, it seems a bit complicated, but in fact it only adds a layer of judgment to the leastconn strategy, and there is no change in other aspects. In order to realize the transition from user mode to kernel mode, I have to do it
I did some implementations to demonstrate
I opened three agents here ` 127.0.0.1:8080 ` `127.0.0.1:1080  ` `127.0.0.1:8081`
> 2020/12/11 16:27:45 server.go:162: [http] 127.0.0.1:56405 <-> www.baidu.com:80 via 127.0.0.1:8080
2020/12/11 16:27:45 server.go:162: [http] 127.0.0.1:56408 <-> www.alibaba.com:80 via 127.0.0.1:1080
2020/12/11 16:27:45 server.go:162: [http] 127.0.0.1:56413 <-> www.tencent.com:80 via 127.0.0.1:8081
2020/12/11 16:27:48 server.go:162: [http] 127.0.0.1:56422 <-> www.baidu.com:80 via 127.0.0.1:8080
2020/12/11 16:27:48 server.go:162: [http] 127.0.0.1:56425 <-> www.alibaba.com:80 via 127.0.0.1:1080
2020/12/11 16:27:48 server.go:162: [http] 127.0.0.1:56428 <-> www.tencent.com:80 via 127.0.0.1:8081
I can do more tests if you need