### PR TITLE
fix(socks5): should not dial returned bind addr directly

### DIFF
--- a/proxy/socks5/client.go
+++ b/proxy/socks5/client.go
@@ -91,14 +91,15 @@ func (s *Socks5) DialUDP(network, addr string) (pc net.PacketConn, writeTo net.A
 	// if returned bind ip is unspecified
 	if ip := net.ParseIP(h); ip != nil && ip.IsUnspecified() {
 		// indicate using conventional addr
-		uAddress = net.JoinHostPort(s.addr, p)
+		h, _, _ = net.SplitHostPort(s.addr)
+		uAddress = net.JoinHostPort(h, p)
 	} else {
 		uAddress = uAddr.String()
 	}
 
 	pc, nextHop, err := s.dialer.DialUDP(network, uAddress)
 	if err != nil {
-		log.F("[socks5] dialudp to %s error: %s", uAddr.String(), err)
+		log.F("[socks5] dialudp to %s error: %s", uAddress, err)
 		return nil, nil, err
 	}
 

--- a/proxy/socks5/client.go
+++ b/proxy/socks5/client.go
@@ -86,7 +86,17 @@ func (s *Socks5) DialUDP(network, addr string) (pc net.PacketConn, writeTo net.A
 		return nil, nil, err
 	}
 
-	pc, nextHop, err := s.dialer.DialUDP(network, uAddr.String())
+	var uAddress string
+	h, p, _ := net.SplitHostPort(uAddr.String())
+	// if returned bind ip is unspecified
+	if ip := net.ParseIP(h); ip != nil && ip.IsUnspecified() {
+		// indicate using conventional addr
+		uAddress = net.JoinHostPort(s.addr, p)
+	} else {
+		uAddress = uAddr.String()
+	}
+
+	pc, nextHop, err := s.dialer.DialUDP(network, uAddress)
 	if err != nil {
 		log.F("[socks5] dialudp to %s error: %s", uAddr.String(), err)
 		return nil, nil, err


### PR DESCRIPTION
When server returns an any ip (0.0.0.0 or [::]), we should use conventional ip to replace the any ip given (0.0.0.0 or [::]). This behaviour adapts to most situations.

See v2fly/v2ray-core#523

---

Problem happens when socks5 proxy works on remote servers and different implementation will given different bind addr.

For most situations it is issues of servers. However, clients should behave normally in one case that returned bind addr is an ANYIP (0.0.0.0 or [::]), which indicate that we should use a conventional remote address to connect.

RFC does not illustrate the mechanism of bind addr; it is based on experience.