### PR TITLE
Quickly close the peer connection use the tcp half-close

### DIFF
--- a/proxy/conn.go
+++ b/proxy/conn.go
@@ -69,7 +69,7 @@ func Relay(left, right net.Conn) error {
 	if lc, ok := left.(interface {
 		CloseWrite() error
 	}); ok {
-		if e := lc.CloseWrite(); err1 == nil && e != io.EOF {
+		if e := lc.CloseWrite(); err == nil && e != io.EOF {
 			err = e
 		}
 	}

--- a/proxy/ss/cipher/internal/shadowaead/conn.go
+++ b/proxy/ss/cipher/internal/shadowaead/conn.go
@@ -65,3 +65,23 @@ func (c *streamConn) Write(b []byte) (int, error) {
 	}
 	return c.w.Write(b)
 }
+
+func (c *streamConn) CloseWrite() error {
+	if conn, ok := c.Conn.(interface {
+		CloseWrite() error
+	}); ok {
+		return conn.CloseWrite()
+	}
+
+	return nil
+}
+
+func (c *streamConn) CloseRead() error {
+	if conn, ok := c.Conn.(interface {
+		CloseRead() error
+	}); ok {
+		return conn.CloseRead()
+	}
+
+	return nil
+}

--- a/proxy/ss/cipher/internal/shadowstream/conn.go
+++ b/proxy/ss/cipher/internal/shadowstream/conn.go
@@ -60,3 +60,23 @@ func (c *conn) Write(b []byte) (int, error) {
 	}
 	return c.w.Write(b)
 }
+
+func (c *conn) CloseWrite() error {
+	if conn, ok := c.Conn.(interface {
+		CloseWrite() error
+	}); ok {
+		return conn.CloseWrite()
+	}
+
+	return nil
+}
+
+func (c *conn) CloseRead() error {
+	if conn, ok := c.Conn.(interface {
+		CloseRead() error
+	}); ok {
+		return conn.CloseRead()
+	}
+
+	return nil
+}


### PR DESCRIPTION
Quickly close the peer connection use the tcp half-close method CloseWrite, instead of just relying on timeout.