### PR TITLE
Add basic tools to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,25 @@
-# build stage
-FROM golang:alpine AS build-env
-RUN apk --no-cache add build-base git gcc
-ADD . /src
-RUN cd /src && go build -v -ldflags "-s -w"
+# Build Stage
+FROM golang:1.16-alpine AS build-env
 
-# final stage
+ADD . /src
+
+RUN apk --no-cache add build-base git gcc \
+    && cd /src && go build -v -ldflags "-s -w"
+
+# Final Stage
 FROM alpine
-RUN apk -U upgrade --no-cache && \
-    apk add --no-cache bind-tools ca-certificates
-WORKDIR /app
+
 COPY --from=build-env /src/glider /app/
+
+RUN apk -U upgrade \
+    && apk add bind-tools ca-certificates shadow \
+    && groupadd -g 1000 glider \
+    && useradd -r -u 1000 -g glider glider \
+    && apk del shadow \
+    && chown -R glider:glider /app
+    && apk -v cache clean
+    
+WORKDIR /app
+USER glider
+
 ENTRYPOINT ["./glider"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ RUN cd /src && go build -v -ldflags "-s -w"
 
 # final stage
 FROM alpine
+RUN apk -U upgrade --no-cache && \
+    apk add --no-cache bind-tools ca-certificates
 WORKDIR /app
 COPY --from=build-env /src/glider /app/
 ENTRYPOINT ["./glider"]


### PR DESCRIPTION
* Added bind-tools (BIND9) to help DNS performance within Docker Networks/Kubernetes.
* Added ca-certificates for common certificates when using HTTPS/TLS
* Temporarily added the `shadow` package to create a user/group for glider. 
* Pinned build image to golang 1.16 instead of latest.
* Glider will now run as `glider` user and the `/app` is now owned by glider.