### PR TITLE
Docker build fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,12 @@ FROM alpine
 
 COPY --from=build-env /src/glider /app/
 
-RUN apk -U upgrade \
-    && apk add bind-tools ca-certificates shadow \
+RUN apk -U upgrade --no-cache \
+    && apk --no-cache add bind-tools ca-certificates shadow \
     && groupadd -g 1000 glider \
     && useradd -r -u 1000 -g glider glider \
-    && apk del shadow \
-    && chown -R glider:glider /app \
-    && apk -v cache clean
+    && apk --no-cache del shadow \
+    && chown -R glider:glider /app
     
 WORKDIR /app
 USER glider


### PR DESCRIPTION
## Done:
* Fix the CI/CD build error regarding Alpine Cache
* Add `--no-cache` flag to `apk del` to remove the repositories warning.

## Build logs:
```
ubuntu@ubuntu-vb:~/Desktop/glider$ docker build . -t glider
Sending build context to Docker daemon  2.385MB
Step 1/9 : FROM golang:1.16-alpine AS build-env
 ---> 270727b8fd0f
Step 2/9 : ADD . /src
 ---> ef63002e8000
Step 3/9 : RUN apk --no-cache add build-base git gcc     && cd /src && go build -v -ldflags "-s -w"
 ---> Running in 20e597a2c842
fetch https://dl-cdn.alpinelinux.org/alpine/v3.13/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.13/community/x86_64/APKINDEX.tar.gz
(1/26) Installing libgcc (10.2.1_pre1-r3)
(2/26) Installing libstdc++ (10.2.1_pre1-r3)
(3/26) Installing binutils (2.35.2-r0)
(4/26) Installing libmagic (5.39-r0)
(5/26) Installing file (5.39-r0)
(6/26) Installing libgomp (10.2.1_pre1-r3)
(7/26) Installing libatomic (10.2.1_pre1-r3)
(8/26) Installing libgphobos (10.2.1_pre1-r3)
(9/26) Installing gmp (6.2.1-r0)
(10/26) Installing isl22 (0.22-r0)
(11/26) Installing mpfr4 (4.1.0-r0)
(12/26) Installing mpc1 (1.2.0-r0)
(13/26) Installing gcc (10.2.1_pre1-r3)
(14/26) Installing musl-dev (1.2.2-r0)
(15/26) Installing libc-dev (0.7.2-r3)
(16/26) Installing g++ (10.2.1_pre1-r3)
(17/26) Installing make (4.3-r0)
(18/26) Installing fortify-headers (1.1-r0)
(19/26) Installing patch (2.7.6-r6)
(20/26) Installing build-base (0.5-r2)
(21/26) Installing brotli-libs (1.0.9-r3)
(22/26) Installing nghttp2-libs (1.42.0-r1)
(23/26) Installing libcurl (7.76.1-r0)
(24/26) Installing expat (2.2.10-r1)
(25/26) Installing pcre2 (10.36-r0)
(26/26) Installing git (2.30.2-r0)
Executing busybox-1.32.1-r6.trigger
OK: 208 MiB in 41 packages
go: downloading github.com/nadoo/conflag v0.2.3
go: downloading github.com/nadoo/ipset v0.3.0
go: downloading github.com/xtaci/kcp-go/v5 v5.6.1
go: downloading golang.org/x/crypto v0.0.0-20210415154028-4f45737414dc
go: downloading github.com/insomniacslk/dhcp v0.0.0-20210420161629-6bd1ce0fd305
go: downloading github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da
go: downloading github.com/dgryski/go-camellia v0.0.0-20191119043421-69a8a13fb23d
go: downloading github.com/dgryski/go-idea v0.0.0-20170306091226-d2fb45a411fb
go: downloading github.com/dgryski/go-rc2 v0.0.0-20150621095337-8a9021637152
go: downloading github.com/klauspost/reedsolomon v1.9.12
go: downloading github.com/pkg/errors v0.9.1
go: downloading github.com/templexxx/xorsimd v0.4.1
go: downloading github.com/tjfoc/gmsm v1.4.0
go: downloading golang.org/x/net v0.0.0-20210420072503-d25e30425868
go: downloading github.com/mdlayher/ethernet v0.0.0-20190606142754-0394541c37b7
go: downloading github.com/mdlayher/raw v0.0.0-20210412142147-51b895745faf
go: downloading github.com/u-root/u-root v7.0.0+incompatible
go: downloading golang.org/x/sys v0.0.0-20210420072515-93ed5bcd2bfe
go: downloading github.com/templexxx/cpu v0.0.7
go: downloading github.com/klauspost/cpuid v1.3.1
go: downloading github.com/klauspost/cpuid/v2 v2.0.6
golang.org/x/crypto/internal/subtle
golang.org/x/crypto/salsa20/salsa
golang.org/x/net/internal/iana
golang.org/x/sys/internal/unsafeheader
github.com/u-root/u-root/pkg/shlex
github.com/nadoo/glider/pool
github.com/nadoo/conflag
github.com/nadoo/glider/log
github.com/nadoo/ipset/internal/netlink
github.com/klauspost/cpuid/v2
github.com/nadoo/glider/proxy
github.com/pkg/errors
github.com/nadoo/ipset
github.com/nadoo/glider/dns
github.com/nadoo/glider/rule
github.com/nadoo/glider/proxy/http
github.com/klauspost/reedsolomon
github.com/templexxx/cpu
github.com/nadoo/glider/ipset
github.com/tjfoc/gmsm/sm4
golang.org/x/crypto/blowfish
github.com/templexxx/xorsimd
golang.org/x/crypto/cast5
golang.org/x/crypto/pbkdf2
golang.org/x/crypto/salsa20
golang.org/x/crypto/tea
golang.org/x/crypto/twofish
golang.org/x/crypto/xtea
golang.org/x/net/bpf
golang.org/x/sys/unix
github.com/nadoo/glider/proxy/protocol/socks
github.com/nadoo/glider/proxy/socks5
github.com/nadoo/glider/proxy/obfs
github.com/nadoo/glider/proxy/mixed
github.com/nadoo/glider/proxy/redir
github.com/nadoo/glider/proxy/reject
github.com/nadoo/glider/proxy/protocol/smux
github.com/nadoo/glider/proxy/socks4
golang.org/x/crypto/chacha20
golang.org/x/crypto/poly1305
golang.org/x/sys/cpu
github.com/nadoo/glider/proxy/smux
golang.org/x/crypto/hkdf
golang.org/x/crypto/curve25519
golang.org/x/crypto/ed25519
golang.org/x/crypto/chacha20poly1305
github.com/aead/chacha20/chacha
golang.org/x/net/internal/socket
golang.org/x/crypto/ssh/internal/bcrypt_pbkdf
golang.org/x/crypto/ssh
github.com/aead/chacha20
github.com/nadoo/glider/proxy/ss/cipher/internal/shadowaead
github.com/nadoo/glider/proxy/ss/cipher/internal/shadowstream
golang.org/x/net/ipv4
golang.org/x/net/ipv6
github.com/nadoo/glider/proxy/ss/cipher
github.com/nadoo/glider/proxy/ss
github.com/dgryski/go-camellia
github.com/dgryski/go-idea
github.com/dgryski/go-rc2
github.com/nadoo/glider/proxy/ssr/internal/tools
github.com/xtaci/kcp-go/v5
github.com/nadoo/glider/proxy/ssr/internal/ssr
github.com/nadoo/glider/proxy/ssr/internal/cipher
github.com/nadoo/glider/proxy/ssr/internal/obfs
github.com/nadoo/glider/proxy/ssr/internal/protocol
github.com/nadoo/glider/proxy/tcp
github.com/nadoo/glider/proxy/tls
github.com/nadoo/glider/proxy/ssr/internal
github.com/nadoo/glider/proxy/ssr
github.com/nadoo/glider/proxy/trojan
github.com/nadoo/glider/proxy/udp
github.com/nadoo/glider/proxy/kcp
github.com/nadoo/glider/proxy/ssh
github.com/nadoo/glider/proxy/unix
github.com/nadoo/glider/proxy/vless
github.com/nadoo/glider/proxy/vmess
github.com/nadoo/glider/proxy/ws
github.com/nadoo/glider/service
github.com/u-root/u-root/pkg/ubinary
github.com/insomniacslk/dhcp/interfaces
github.com/u-root/u-root/pkg/uio
github.com/insomniacslk/dhcp/rfc1035label
github.com/u-root/u-root/pkg/cmdline
github.com/mdlayher/ethernet
github.com/mdlayher/raw
github.com/u-root/u-root/pkg/rand
github.com/insomniacslk/dhcp/iana
github.com/insomniacslk/dhcp/dhcpv4
github.com/insomniacslk/dhcp/dhcpv4/server4
github.com/insomniacslk/dhcp/dhcpv4/nclient4
github.com/nadoo/glider/service/dhcpd
github.com/nadoo/glider
Removing intermediate container 20e597a2c842
 ---> 0b1e4dcce5bb
Step 4/9 : FROM alpine
 ---> 6dbb9cc54074
Step 5/9 : COPY --from=build-env /src/glider /app/
 ---> Using cache
 ---> acfc84e69b35
Step 6/9 : RUN apk -U upgrade --no-cache     && apk --no-cache add bind-tools ca-certificates shadow     && groupadd -g 1000 glider     && useradd -r -u 1000 -g glider glider     && apk --no-cache del shadow     && chown -R glider:glider /app
 ---> Running in a458b030d597
fetch https://dl-cdn.alpinelinux.org/alpine/v3.13/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.13/community/x86_64/APKINDEX.tar.gz
OK: 6 MiB in 14 packages
fetch https://dl-cdn.alpinelinux.org/alpine/v3.13/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.13/community/x86_64/APKINDEX.tar.gz
(1/20) Installing fstrm (0.6.0-r1)
(2/20) Installing krb5-conf (1.0-r2)
(3/20) Installing libcom_err (1.45.7-r0)
(4/20) Installing keyutils-libs (1.6.3-r0)
(5/20) Installing libverto (0.3.1-r1)
(6/20) Installing krb5-libs (1.18.3-r1)
(7/20) Installing json-c (0.15-r1)
(8/20) Installing libgcc (10.2.1_pre1-r3)
(9/20) Installing libstdc++ (10.2.1_pre1-r3)
(10/20) Installing libprotobuf (3.13.0-r2)
(11/20) Installing libprotoc (3.13.0-r2)
(12/20) Installing protobuf-c (1.3.3-r4)
(13/20) Installing libuv (1.40.0-r0)
(14/20) Installing xz-libs (5.2.5-r0)
(15/20) Installing libxml2 (2.9.10-r6)
(16/20) Installing bind-libs (9.16.11-r1)
(17/20) Installing bind-tools (9.16.11-r1)
(18/20) Installing ca-certificates (20191127-r5)
(19/20) Installing linux-pam (1.5.1-r0)
(20/20) Installing shadow (4.8.1-r0)
Executing busybox-1.32.1-r6.trigger
Executing ca-certificates-20191127-r5.trigger
OK: 22 MiB in 34 packages
fetch https://dl-cdn.alpinelinux.org/alpine/v3.13/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.13/community/x86_64/APKINDEX.tar.gz
(1/2) Purging shadow (4.8.1-r0)
(2/2) Purging linux-pam (1.5.1-r0)
Executing busybox-1.32.1-r6.trigger
OK: 20 MiB in 32 packages
Removing intermediate container a458b030d597
 ---> 1cc4af38b6a8
Step 7/9 : WORKDIR /app
 ---> Running in 32f576cb1b3d
Removing intermediate container 32f576cb1b3d
 ---> c7d82afd1583
Step 8/9 : USER glider
 ---> Running in 653c0d5f9fb0
Removing intermediate container 653c0d5f9fb0
 ---> 74d8b3843a8a
Step 9/9 : ENTRYPOINT ["./glider"]
 ---> Running in ea7db9f0d250
Removing intermediate container ea7db9f0d250
 ---> 60fcbf22d8c5
Successfully built 60fcbf22d8c5
Successfully tagged glider:latest
```

## Run command:

```
ubuntu@ubuntu-vb:~/Desktop/glider$ docker run -it glider:latest -listen :8443 -verbose
2021/04/22 03:35:24 group.go:182: [group] only 1 forwarder found, disable health checking
2021/04/22 03:35:24 mixed.go:68: [mixed] listening TCP on :8443
2021/04/22 03:35:24 server.go:105: [socks5] listening UDP on :8443
```

```
buntu@ubuntu-vb:~/Desktop/glider$ docker run -it glider:latest -listen tcp://:8080 -forward tcp://2.2.2.2:8 -verbose
2021/04/22 03:36:42 group.go:182: [group] only 1 forwarder found, disable health checking
2021/04/22 03:36:42 tcp.go:60: [tcp] listening TCP on :8080
```

```
ubuntu@ubuntu-vb:~/Desktop/glider$ docker run -it glider:latest -listen ss://AEAD_CHACHA20_POLY1305:pass@:8443 -verbose
2021/04/22 03:37:45 group.go:182: [group] only 1 forwarder found, disable health checking
2021/04/22 03:37:45 server.go:34: [ss] listening TCP on :8443
2021/04/22 03:37:45 server.go:96: [ss] listening UDP on :8443
```

