### PR TITLE
fix(trojan): potential memory leak

### DIFF
--- a/proxy/trojan/server.go
+++ b/proxy/trojan/server.go
@@ -84,6 +84,7 @@ func (s *Trojan) Serve(c net.Conn) {
 
 	if s.withTLS {
 		tlsConn := tls.Server(c, s.tlsConfig)
+		defer tlsConn.Close()
 		err := tlsConn.Handshake()
 		if err != nil {
 			log.F("[trojan] error in tls handshake: %s", err)


### PR DESCRIPTION
I can stably observe that when using Trojan as the server, there will be memory leak issues.

When I investigate the problem, I found it related to the fallback. I mean that the problem is particularly obvious when fallback address is not set.

After code auditing, I fixed a possible leak, but I can't guarantee that the problem was completely repaired, because I have not conducted further testing.

https://github.com/golang/go/blob/master/src/crypto/tls/conn.go#L1314