### PR TITLE
feat(vmess): add length mask (opt=4)

### DIFF
--- a/proxy/vmess/chunk_size_parser.go
+++ b/proxy/vmess/chunk_size_parser.go
@@ -1,0 +1,60 @@
+package vmess
+
+import (
+	"encoding/binary"
+	"golang.org/x/crypto/sha3"
+)
+
+// ChunkSizeEncoder is a utility class to encode size value into bytes.
+type ChunkSizeEncoder interface {
+	SizeBytes() int32
+	Encode(uint16, []byte) []byte
+}
+
+// ChunkSizeDecoder is a utility class to decode size value from bytes.
+type ChunkSizeDecoder interface {
+	SizeBytes() int32
+	Decode([]byte) (uint16, error)
+}
+
+type ShakeSizeParser struct {
+	shake  sha3.ShakeHash
+	buffer [2]byte
+}
+
+func NewShakeSizeParser(nonce []byte) *ShakeSizeParser {
+	shake := sha3.NewShake128()
+	shake.Write(nonce)
+	return &ShakeSizeParser{
+		shake: shake,
+	}
+}
+
+func (*ShakeSizeParser) SizeBytes() int32 {
+	return 2
+}
+
+func (s *ShakeSizeParser) next() uint16 {
+	s.shake.Read(s.buffer[:])
+	return binary.BigEndian.Uint16(s.buffer[:])
+}
+
+func (s *ShakeSizeParser) Decode(b []byte) (uint16, error) {
+	mask := s.next()
+	size := binary.BigEndian.Uint16(b)
+	return mask ^ size, nil
+}
+
+func (s *ShakeSizeParser) Encode(size uint16, b []byte) []byte {
+	mask := s.next()
+	binary.BigEndian.PutUint16(b, mask^size)
+	return b[:2]
+}
+
+func (s *ShakeSizeParser) NextPaddingLen() uint16 {
+	return s.next() % 64
+}
+
+func (s *ShakeSizeParser) MaxPaddingLen() uint16 {
+	return 64
+}


### PR DESCRIPTION
The vmess implementation of glider did not have `opt=4` which is length confusion. The middleman can easily get a feature by comparing the length of the first 2 bytes (plaintext of length) of the chunk with the actual length of the TCP stream chunk.

For example, if there is a port that does not meet this feature (with opt=4) and another meets the feature, and the port is confirmed unknown traffic, it can be preliminarily judged to be vmess.