### PR TITLE
Run glider as non-root user

### DIFF
--- a/.Dockerfile
+++ b/.Dockerfile
@@ -23,7 +23,17 @@ RUN arch="$(apk --print-arch)"; \
     rm /dist -rf
 
 FROM alpine
-RUN apk add --no-cache ca-certificates
-COPY --from=build-env /app /app
+
 WORKDIR /app
+COPY --from=build-env /app /app
+
+RUN apk -U upgrade --no-cache \
+    && apk --no-cache add ca-certificates shadow \
+    && groupadd -g 1000 glider \
+    && useradd -r -u 1000 -g glider glider \
+    && apk --no-cache del shadow \
+    && chown -R glider:glider /app \
+    && chmod +x /app/glider
+    
+USER glider
 ENTRYPOINT ["./glider"]


### PR DESCRIPTION
Two minimal changes based on the current Dockerfile

* Alpine only updates their docker image when there's a new release (3 months ago), by running  `apk -U --no-cache upgrade` we will get these updates: 

```
/ # apk -U --no-cache upgrade
fetch https://dl-cdn.alpinelinux.org/alpine/v3.15/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.15/community/x86_64/APKINDEX.tar.gz
(1/6) Upgrading busybox (1.34.1-r3 -> 1.34.1-r4)
Executing busybox-1.34.1-r4.post-upgrade
(2/6) Upgrading ca-certificates-bundle (20191127-r7 -> 20211220-r0)
(3/6) Upgrading libcrypto1.1 (1.1.1l-r7 -> 1.1.1l-r8)
(4/6) Upgrading libssl1.1 (1.1.1l-r7 -> 1.1.1l-r8)
(5/6) Upgrading ssl_client (1.34.1-r3 -> 1.34.1-r4)
(6/6) Upgrading ca-certificates (20191127-r7 -> 20211220-r0)
Executing busybox-1.34.1-r4.trigger
Executing ca-certificates-20211220-r0.trigger
OK: 6 MiB in 15 packages
```

* The current glider image runs as a non-root user, the new image should keep that approach. This is required in a lot of environments, and it's a security improvement.
* During the same `RUN` we remove  `shadow` so the image will not increase in size. 