### PR TITLE
Keep cache for upgraded packages.

### DIFF
--- a/.Dockerfile
+++ b/.Dockerfile
@@ -27,7 +27,7 @@ FROM alpine
 WORKDIR /app
 COPY --from=build-env /app /app
 
-RUN apk -U upgrade --no-cache \
+RUN apk -U upgrade \
     && apk --no-cache add ca-certificates shadow \
     && groupadd -g 1000 glider \
     && useradd -r -u 1000 -g glider glider \


### PR DESCRIPTION
I was checking how we do the build in another project, and  we are not using `--no-cache` during `apk upgrade` for ARM.

I also wanted to point out, that `glider` should probably run builds for PR's, I can add that in a separate PR this weekend. 

Fix for #314 